### PR TITLE
.github/workflows/rust.yml: Set permissions explicitly; rename job to…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,14 +6,21 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build_and_test:
+    runs-on: ${{ matrix.os }}
 
-    runs-on: ubuntu-22.04
-
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-2022, windows-2025-vs2026, macos-15, macos-26, ubuntu-22.04, ubuntu-24.04 ]
+        
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Build


### PR DESCRIPTION
… `build_and_test`; run on multiple OSes